### PR TITLE
libast.m4: Avoid implicit declaration of exit

### DIFF
--- a/libast.m4
+++ b/libast.m4
@@ -505,10 +505,10 @@ char ovbuf[7];
 int i;
 for (i=0; i<7; i++) ovbuf[i]='x';
 snprintf(ovbuf, 4,"foo%s", "bar");
-if (ovbuf[5]!='x') exit(1);
+if (ovbuf[5]!='x') return 1;
 snprintf(ovbuf, 4,"foo%d", 666);
-if (ovbuf[5]!='x') exit(1);
-exit(0);
+if (ovbuf[5]!='x') return 1;
+return 0;
 } >>
             changequote([, ])
         , dps_cv_snprintf_bug=0, dps_cv_snprintf_bug=1, dps_cv_snprintf_bug=2)
@@ -550,10 +550,10 @@ int main(void)
   char ovbuf[8] = "xxxxxxx";
   int i;
   prnt(ovbuf, "foo%s", "bar");
-  if (ovbuf[5]!='x') {fprintf(stderr, "buffer:  %s\n", ovbuf); exit(1);}
+  if (ovbuf[5]!='x') {fprintf(stderr, "buffer:  %s\n", ovbuf); return 1;}
   prnt(ovbuf, "foo%d", 666);
-  if (ovbuf[5]!='x') {fprintf(stderr, "buffer:  %s\n", ovbuf); exit(1);}
-  exit(0);
+  if (ovbuf[5]!='x') {fprintf(stderr, "buffer:  %s\n", ovbuf); return 1;}
+  return 0;
 } >>
             changequote([, ])
         , dps_cv_vsnprintf_bug=0, dps_cv_vsnprintf_bug=1, dps_cv_vsnprintf_bug=2)
@@ -651,10 +651,10 @@ AC_DEFUN([dps_rlimit_nproc], [
         AC_TRY_RUN(
             changequote(<<, >>)dnl
 <<
-#ifndef HAVE_STDLIB_H
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif /* HAVE_STDLIB_H */
-#ifndef HAVE_SIGNAL_H
+#ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif /* HAVE_SIGNAL_H */
 #ifdef HAVE_UNISTD_H
@@ -699,10 +699,10 @@ AC_DEFUN([dps_rlimit_memlock], [
         AC_TRY_RUN(
             changequote(<<, >>)dnl
 <<
-#ifndef HAVE_STDLIB_H
+#ifdef HAVE_STDLIB_H
 #include <stdlib.h>
 #endif /* HAVE_STDLIB_H */
-#ifndef HAVE_SIGNAL_H
+#ifdef HAVE_SIGNAL_H
 #include <signal.h>
 #endif /* HAVE_SIGNAL_H */
 #ifdef HAVE_UNISTD_H


### PR DESCRIPTION
Future compilers will not support implicit function declarations by default, and without this change, some of the configure checks will always fail.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
